### PR TITLE
Adding support for Download Platforms

### DIFF
--- a/.github/workflows/swift-test.yml
+++ b/.github/workflows/swift-test.yml
@@ -58,10 +58,16 @@ jobs:
             deviceName: "Apple Vision Pro"
             osVersion: "2.5"
 
-          - type: visionos
+          - type: tvos
+            runs-on: macos-15
+            xcode: "/Applications/Xcode_16.4.app"
+            deviceName: "Apple TV 4K (3rd generation)"
+            osVersion: "18.5"
+
+          - type: tvos
             runs-on: macos-15
             xcode: "/Applications/Xcode_26_beta.app"
-            deviceName: "Apple Vision Pro 4K"
+            deviceName: "Apple TV 4K (3rd generation)"
             osVersion: "26.0"
             download-platform: "true"
     steps:
@@ -124,11 +130,17 @@ jobs:
             deviceName: "Apple Vision Pro"
             osVersion: "2.5"
 
-          - type: visionos
+          - type: tvos
+            runs-on: macos-15
+            xcode: "/Applications/Xcode_16.4.app"
+            deviceName: "Apple TV 4K (3rd generation)"
+            osVersion: "18.5"
+
+          - type: tvos
             runs-on: macos-15
             xcode: "/Applications/Xcode_26_beta.app"
-            deviceName: "Apple Vision Pro"
-            osVersion: "2.5"
+            deviceName: "Apple TV 4K (3rd generation)"
+            osVersion: "26.0"
             download-platform: "true"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/swift-test.yml
+++ b/.github/workflows/swift-test.yml
@@ -31,6 +31,13 @@ jobs:
             xcode: "/Applications/Xcode_16.4.app"
             deviceName: "iPhone 16 Pro"
             osVersion: "18.5"
+
+          - type: ios
+            runs-on: macos-15
+            xcode: "/Applications/Xcode_26_beta.app"
+            deviceName: "iPhone 16 Pro"
+            osVersion: "26.0"
+            download-platform: "true"
   
           - type: watchos
             runs-on: macos-15
@@ -38,11 +45,25 @@ jobs:
             deviceName: "Apple Watch Ultra 2 (49mm)"
             osVersion: "11.5"
 
+          - type: watchos
+            runs-on: macos-15
+            xcode: "/Applications/Xcode_26_beta.app"
+            deviceName: "Apple Watch Ultra 2 (49mm)"
+            osVersion: "26.0"
+            download-platform: "true"
+
           - type: visionos
             runs-on: macos-15
             xcode: "/Applications/Xcode_16.4.app"
             deviceName: "Apple Vision Pro"
             osVersion: "2.5"
+
+          - type: visionos
+            runs-on: macos-15
+            xcode: "/Applications/Xcode_26_beta.app"
+            deviceName: "Apple Vision Pro"
+            osVersion: "26.0"
+            download-platform: "true"
     steps:
       - uses: actions/checkout@v4
       - uses: ./
@@ -53,6 +74,7 @@ jobs:
           xcode: ${{ matrix.xcode }}
           deviceName: ${{ matrix.deviceName }}
           osVersion: ${{ matrix.osVersion }}
+          download-platform: ${{ matrix.download-platform || 'false' }}
 
   test-multi-target-macos:
     name: Test Multi-Target Package (macOS)
@@ -75,6 +97,13 @@ jobs:
             xcode: "/Applications/Xcode_16.4.app"
             deviceName: "iPhone 16 Pro"
             osVersion: "18.5"
+
+          - type: ios
+            runs-on: macos-15
+            xcode: "/Applications/Xcode_26_beta.app"
+            deviceName: "iPhone 16 Pro"
+            osVersion: "18.5"
+            download-platform: "true"
   
           - type: watchos
             runs-on: macos-15
@@ -82,11 +111,25 @@ jobs:
             deviceName: "Apple Watch Ultra 2 (49mm)"
             osVersion: "11.5"
 
+          - type: watchos
+            runs-on: macos-15
+            xcode: "/Applications/Xcode_26_beta.app"
+            deviceName: "Apple Watch Ultra 2 (49mm)"
+            osVersion: "11.5"
+            download-platform: "true"
+
           - type: visionos
             runs-on: macos-15
             xcode: "/Applications/Xcode_16.4.app"
             deviceName: "Apple Vision Pro"
             osVersion: "2.5"
+
+          - type: visionos
+            runs-on: macos-15
+            xcode: "/Applications/Xcode_26_beta.app"
+            deviceName: "Apple Vision Pro"
+            osVersion: "2.5"
+            download-platform: "true"
     steps:
       - uses: actions/checkout@v4
       - uses: ./
@@ -97,6 +140,7 @@ jobs:
           xcode: ${{ matrix.xcode }}
           deviceName: ${{ matrix.deviceName }}
           osVersion: ${{ matrix.osVersion }}
+          download-platform: ${{ matrix.download-platform || 'false' }}
 
   test-single-target-ubuntu:
     name: Test Single Target Package (Ubuntu)

--- a/.github/workflows/swift-test.yml
+++ b/.github/workflows/swift-test.yml
@@ -61,7 +61,7 @@ jobs:
           - type: visionos
             runs-on: macos-15
             xcode: "/Applications/Xcode_26_beta.app"
-            deviceName: "Apple Vision Pro"
+            deviceName: "Apple Vision Pro 4K"
             osVersion: "26.0"
             download-platform: "true"
     steps:

--- a/.github/workflows/swift-test.yml
+++ b/.github/workflows/swift-test.yml
@@ -164,15 +164,27 @@ jobs:
           - "5.10"
           - "6.0"
           - "6.1"
+          - "6.2"
         ubuntu:
           - jammy
           - focal
           - noble
+        nightly:
+          - false
+          - true
         exclude:
           - swift: 5.9
             ubuntu: noble
+          - swift: 5.9
+            nightly: true
+          - swift: 5.10
+            nightly: true
+          - swift: 6.0
+            nightly: true
+          - swift: 6.2
+            nightly: false
     container:
-      image: swift:${{ matrix.swift }}-${{ matrix.ubuntu }}
+      image: ${{ matrix.nightly && format('swiftlang/swift:nightly-{0}-{1}', matrix.swift, matrix.ubuntu) || format('swift:{0}-{1}', matrix.swift, matrix.ubuntu) }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./
@@ -190,15 +202,27 @@ jobs:
           - "5.10"
           - "6.0"
           - "6.1"
+          - "6.2"
         ubuntu:
           - jammy
           - focal
           - noble
+        nightly:
+          - false
+          - true
         exclude:
           - swift: 5.9
             ubuntu: noble
+          - swift: 5.9
+            nightly: true
+          - swift: 5.10
+            nightly: true
+          - swift: 6.0
+            nightly: true
+          - swift: 6.2
+            nightly: false
     container:
-      image: swift:${{ matrix.swift }}-${{ matrix.ubuntu }}
+      image: ${{ matrix.nightly && format('swiftlang/swift:nightly-{0}-{1}', matrix.swift, matrix.ubuntu) || format('swift:{0}-{1}', matrix.swift, matrix.ubuntu) }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
   osVersion:
     description: 'Simulator OS version for Apple platforms'
     required: false
+  download-platform:
+    description: 'Whether to download the platform if not available'
+    required: false
+    default: 'false'
 
 runs:
   using: "composite"
@@ -75,6 +79,26 @@ runs:
           macos)
             echo "PLATFORM=macOS" >> $GITHUB_ENV
             echo "SDK=macosx" >> $GITHUB_ENV
+            ;;
+        esac
+
+    - name: Download Platform
+      if: steps.detect-os.outputs.os == 'macos' && inputs.type && inputs.download-platform == 'true'
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        case ${{ inputs.type }} in
+          ios)
+            xcodebuild -downloadPlatform iOS
+            ;;
+          watchos)
+            xcodebuild -downloadPlatform watchOS
+            ;;
+          visionos)
+            xcodebuild -downloadPlatform visionOS
+            ;;
+          tvos)
+            xcodebuild -downloadPlatform tvOS
             ;;
         esac
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for testing with Xcode 26 beta and macOS 15 in automated workflows for iOS, watchOS, and tvOS.
  * Introduced an option to automatically download the required Apple platform SDKs during test runs.
  * Extended Ubuntu test workflows to include Swift 6.2 and nightly Swift builds for broader coverage.

* **Chores**
  * Expanded test configurations to cover new beta environments for improved platform compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->