### PR TITLE
Add disk space cleanup for Android emulator jobs

### DIFF
--- a/.github/workflows/swift-test.yml
+++ b/.github/workflows/swift-test.yml
@@ -666,6 +666,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Free disk space (Ubuntu)
+        if: matrix.build-only == false
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: false
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - uses: ./
         with:
           working-directory: test/SingleTargetPackage
@@ -705,6 +717,18 @@ jobs:
             build-only: true
     steps:
       - uses: actions/checkout@v4
+
+      - name: Free disk space (Ubuntu)
+        if: matrix.build-only == false
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: false
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
 
       - uses: ./
         with:
@@ -821,6 +845,17 @@ jobs:
             android-run-tests: "true"
     steps:
       - uses: actions/checkout@v4
+
+      - name: Free disk space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: false
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
 
       - uses: ./
         with:


### PR DESCRIPTION
Fixes timeout issues in Android jobs that run emulator tests.

The Android emulator was failing to boot with error: "FATAL | Your device does not have enough disk space to run avd"

This caused the jobs to timeout after ~13 minutes waiting for the emulator that never started.

Solution: Use jlumbroso/free-disk-space action to clean up unnecessary files before launching the emulator. This removes:
- .NET tools
- Haskell
- Large packages
- Docker images
- Swap storage

Only runs for jobs with android-run-tests: true and build-only: false, since build-only jobs don't need the emulator.

Affected jobs:
- Test Single Target Package (Android) - build-only: false
- Test Multi-Target Package (Android) - build-only: false
- Test Dependency Package (Android)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/brightdigit/swift-build/56)
<!-- GitContextEnd -->