### PR TITLE
Re-resolve floating deps in skip-package-resolved mode (#101)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1448,6 +1448,38 @@ runs:
     # - Build artifacts cached via .build directory (60-80% time reduction)
     # - Force-resolved-versions prevents dependency resolution inconsistencies
     # - Cache-path flag enables local build artifact reuse
+
+    # Refresh floating dependencies (skip-package-resolved mode)
+    # When skip-package-resolved=true with a floating (branch) dependency, a restored build cache
+    # contains a frozen workspace-state.json + checkouts and would never advance the branch tip
+    # (--force-resolved-versions is intentionally omitted in skip mode). Remove the stale resolution
+    # state so the upcoming build re-resolves floating deps to their current tip, while still reusing
+    # the compiled-artifact cache. This only runs in skip mode; the normal pinned path is untouched.
+    # Runs after all cache-restore steps and before every platform's build/test step.
+    - name: Refresh floating dependencies (skip mode)
+      if: inputs.skip-package-resolved == 'true'
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        echo "skip-package-resolved=true: clearing stale resolution state so floating deps re-resolve"
+
+        # SPM (.build) resolution state
+        rm -f .build/workspace-state.json 2>/dev/null || true
+
+        # Xcode DerivedData SourcePackages resolution state (Apple-platform builds)
+        if [[ -n "${DERIVED_DATA_PATH:-}" ]]; then
+          find "$DERIVED_DATA_PATH" -name 'workspace-state.json' -delete 2>/dev/null || true
+        fi
+
+        # Remove any restored Package.resolved so SPM/xcodebuild resolve from scratch
+        rm -f Package.resolved 2>/dev/null || true
+
+        # Re-resolve dependencies to advance floating branch deps to their current tip.
+        # Best-effort: skipped cleanly if there are no dependencies or the resolver is unavailable.
+        if command -v swift >/dev/null 2>&1; then
+          swift package update 2>/dev/null || swift package resolve 2>/dev/null || true
+        fi
+
     - name: Build${{ inputs.build-only == 'true' && '' || ' and Test' }}
       if: (steps.detect-os.outputs.os == 'macos' && !inputs.type) || steps.detect-os.outputs.os == 'ubuntu' || steps.detect-os.outputs.os == 'windows'
       shell: bash


### PR DESCRIPTION
## Summary
Fixes floating (branch) dependencies being frozen when `skip-package-resolved: true` is used with build caching.

**Root cause:** in skip mode the cache key uses a constant `no-resolved`, so a restored `.build` (SPM) / DerivedData SourcePackages (Xcode) keeps a frozen `workspace-state.json` + checkouts and never re-resolves — `--force-resolved-versions` is intentionally omitted, and nothing advances the branch tip.

**Fix:** add a "Refresh floating dependencies (skip mode)" step, gated on `skip-package-resolved == 'true'`, that runs after cache restore and before each build. It clears stale resolution state (`.build/workspace-state.json`, DerivedData `workspace-state.json`, any restored `Package.resolved`) and re-resolves via `swift package update` (falling back to `swift package resolve`). The compiled-artifact cache is still reused.

The normal pinned path (`skip-package-resolved: false`) is completely untouched, preserving its cache-hit rate.

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)