### PR TITLE
Auto-calculate Xcode scheme for Swift packages (#100)

### DIFF
--- a/.github/workflows/swift-test.yml
+++ b/.github/workflows/swift-test.yml
@@ -920,7 +920,6 @@ jobs:
         uses: ./
         with:
           working-directory: test/SingleTargetPackage
-          scheme: SingleTargetPackage
           type: macos
           # These Android params should be IGNORED since type is explicitly set to macos
           android-api-level: "31"

--- a/.github/workflows/swift-test.yml
+++ b/.github/workflows/swift-test.yml
@@ -116,7 +116,6 @@ jobs:
         id: build
         with:
           working-directory: test/SingleTargetPackage
-          scheme: SingleTargetPackage
           type: ${{ matrix.type }}
           xcode: ${{ matrix.xcode }}
           deviceName: ${{ matrix.deviceName }}
@@ -233,7 +232,6 @@ jobs:
       - uses: ./
         with:
           working-directory: test/MultiTargetPackage
-          scheme: MultiTargetPackage-Package
           type: ${{ matrix.type }}
           xcode: ${{ matrix.xcode }}
           deviceName: ${{ matrix.deviceName }}
@@ -277,7 +275,6 @@ jobs:
       - uses: ./
         with:
           working-directory: test/MixedFrameworkPackage
-          scheme: MixedFrameworkPackage-Package
           type: ${{ matrix.type }}
           xcode: ${{ matrix.xcode }}
           deviceName: ${{ matrix.deviceName }}
@@ -349,7 +346,6 @@ jobs:
         id: build
         with:
           working-directory: test/SingleTargetPackage
-          scheme: SingleTargetPackage
           use-xcbeautify: "true"
           skip-package-resolved: "true"
           build-only: ${{ matrix['build-only'] || 'false' }}
@@ -398,7 +394,6 @@ jobs:
       - uses: ./
         with:
           working-directory: test/MultiTargetPackage
-          scheme: MultiTargetPackage
           xcbeautify-renderer: "github-actions"
           skip-package-resolved: "true"
           build-only: ${{ matrix['build-only'] || 'false' }}
@@ -432,7 +427,6 @@ jobs:
       - uses: ./
         with:
           working-directory: test/MixedFrameworkPackage
-          scheme: MixedFrameworkPackage
           use-xcbeautify: "true"
           skip-package-resolved: "true"
           save-test-output: 'true'
@@ -461,7 +455,6 @@ jobs:
         id: build
         with:
           working-directory: test/SingleTargetPackage
-          scheme: SingleTargetPackage
           windows-swift-version: swift-${{ matrix.swift-version }}-release
           windows-swift-build: ${{ matrix.swift-version }}-RELEASE
           use-xcbeautify: "true"
@@ -497,7 +490,6 @@ jobs:
         id: build
         with:
           working-directory: test/MultiTargetPackage
-          scheme: MultiTargetPackage-Package
           windows-swift-version: swift-${{ matrix.swift-version }}-release
           windows-swift-build: ${{ matrix.swift-version }}-RELEASE
           use-xcbeautify: "true"
@@ -530,7 +522,6 @@ jobs:
       - uses: ./
         with:
           working-directory: test/MixedFrameworkPackage
-          scheme: MixedFrameworkPackage-Package
           windows-swift-version: swift-${{ matrix.swift-version }}-release
           windows-swift-build: ${{ matrix.swift-version }}-RELEASE
           use-xcbeautify: "true"
@@ -557,7 +548,6 @@ jobs:
       - uses: ./
         with:
           working-directory: test/SymlinkDependencyPackage
-          scheme: SymlinkDependencyPackage-Package
           windows-swift-version: swift-${{ matrix.swift-version }}-release
           windows-swift-build: ${{ matrix.swift-version }}-RELEASE
           use-xcbeautify: "true"
@@ -603,7 +593,6 @@ jobs:
       - uses: ./
         with:
           working-directory: test/DependencyPackage
-          scheme: DependencyPackage
           use-xcbeautify: "true"
 
   test-dependency-package-resolved-v3-failure:
@@ -626,7 +615,6 @@ jobs:
         uses: ./
         with:
           working-directory: test/DependencyPackage
-          scheme: DependencyPackage
           use-xcbeautify: "true"
       - name: Verify test failed as expected
         if: always() && steps.strict-test.outcome == 'failure'
@@ -662,7 +650,6 @@ jobs:
         uses: ./
         with:
           working-directory: test/DependencyPackage
-          scheme: DependencyPackage
           use-xcbeautify: "true"
           skip-package-resolved: "true"
 
@@ -679,7 +666,6 @@ jobs:
       - uses: ./
         with:
           working-directory: test/DependencyPackage
-          scheme: DependencyPackage-Package
           windows-swift-version: swift-${{ matrix.swift-version }}-release
           windows-swift-build: ${{ matrix.swift-version }}-RELEASE
           use-xcbeautify: "true"
@@ -693,7 +679,6 @@ jobs:
       - uses: ./
         with:
           working-directory: test/DependencyPackage
-          scheme: DependencyPackage
           xcode: "/Applications/Xcode_16.4.app"
           use-xcbeautify: "true"
           skip-package-resolved: "false"
@@ -735,7 +720,6 @@ jobs:
         id: build
         with:
           working-directory: test/SingleTargetPackage
-          scheme: SingleTargetPackage
           type: android
           android-swift-version: ${{ matrix.android-swift-version }}
           android-api-level: ${{ matrix.android-api-level }}
@@ -794,7 +778,6 @@ jobs:
       - uses: ./
         with:
           working-directory: test/MultiTargetPackage
-          scheme: MultiTargetPackage-Package
           type: android
           android-swift-version: ${{ matrix.android-swift-version }}
           android-api-level: ${{ matrix.android-api-level }}
@@ -835,7 +818,6 @@ jobs:
       - uses: ./
         with:
           working-directory: test/MixedFrameworkPackage
-          scheme: MixedFrameworkPackage-Package
           type: android
           android-swift-version: ${{ matrix.android-swift-version }}
           android-api-level: ${{ matrix.android-api-level }}
@@ -893,7 +875,6 @@ jobs:
         uses: ./
         with:
           working-directory: test/SingleTargetPackage
-          scheme: SingleTargetPackage
           # NOTE: type is NOT set - should auto-detect Android
           android-swift-version: ${{ matrix.android-swift-version }}
           android-api-level: ${{ matrix.android-api-level }}
@@ -959,7 +940,6 @@ jobs:
       - uses: ./
         with:
           working-directory: test/DependencyPackage
-          scheme: DependencyPackage
           type: android
           android-swift-version: ${{ matrix.android-swift-version }}
           android-api-level: ${{ matrix.android-api-level }}
@@ -979,7 +959,6 @@ jobs:
         uses: ./
         with:
           working-directory: test/DependencyPackage
-          scheme: DependencyPackage
           skip-package-resolved: "false"
 
       # Second build should hit cache
@@ -987,7 +966,6 @@ jobs:
         uses: ./
         with:
           working-directory: test/DependencyPackage
-          scheme: DependencyPackage
           skip-package-resolved: "false"
 
   test-cache-behavior-floating:
@@ -1007,7 +985,6 @@ jobs:
         uses: ./
         with:
           working-directory: test/DependencyPackage
-          scheme: DependencyPackage
           skip-package-resolved: "true"
 
       # Second build should hit cache with 'no-resolved' key
@@ -1015,7 +992,6 @@ jobs:
         uses: ./
         with:
           working-directory: test/DependencyPackage
-          scheme: DependencyPackage
           skip-package-resolved: "true"
 
   test-single-target-wasm:
@@ -1151,7 +1127,6 @@ jobs:
         id: build
         with:
           working-directory: test/SingleTargetPackage
-          scheme: SingleTargetPackage
           type: ${{ matrix.type }}
           xcode: ${{ matrix.xcode }}
           skip-package-resolved: "true"
@@ -1306,7 +1281,6 @@ jobs:
       - uses: ./
         with:
           working-directory: test/MultiTargetPackage
-          scheme: MultiTargetPackage-Package
           type: ${{ matrix.type }}
           xcode: ${{ matrix.xcode }}
           skip-package-resolved: "true"
@@ -1365,7 +1339,6 @@ jobs:
       - uses: ./
         with:
           working-directory: test/MixedFrameworkPackage
-          scheme: MixedFrameworkPackage-Package
           type: ${{ matrix.type }}
           xcode: ${{ matrix.xcode }}
           skip-package-resolved: "true"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ Override auto-detection with the `wasm-testing-library` parameter:
 ### Inputs
 
 The action accepts these key inputs:
-- `scheme` (required) - The scheme to build and test
+- `scheme` (optional) - The scheme to build and test. On Apple-platform builds it is auto-calculated from the Swift package when omitted (single product → product name; multiple products → `<PackageName>-Package`).
 - `working-directory` - Directory containing the Swift package (default: '.')
 - `type` - Build type for Apple platforms (ios, watchos, visionos, tvos, macos)
 - `xcode` - Xcode version path for Apple platforms

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 
 | Parameter | Description | Default | Example | Valid Values | Used By |
 |-----------|-------------|---------|---------|--------------|---------|
-| `scheme` | The scheme to build and test | Required when `type` specified | `MyPackage-Package` | Any valid scheme name | **Xcode builds only** - Required when `type` is specified (iOS, watchOS, tvOS, visionOS, macOS simulator testing). Not needed for SwiftPM builds (Ubuntu/macOS) |
+| `scheme` | The scheme to build and test | Auto-calculated | `MyPackage-Package` | Any valid scheme name | **Xcode builds only** - Optional. When omitted on Apple-platform builds (iOS, watchOS, tvOS, visionOS, macOS) it is auto-derived from the Swift package: a single product uses the product name; multiple products use `<PackageName>-Package`. Provide explicitly to override. Not needed for SwiftPM builds (Ubuntu/macOS) |
 | `working-directory` | Directory containing the Swift package | `.` | `./MyPackage` | Any valid directory path | **All platforms** - SwiftPM (Ubuntu/macOS) and Xcode builds |
 | `type` | Build type | `null` | `ios` | `ios`, `watchos`, `visionos`, `tvos`, `macos`, `android` | **Platform selection** - Apple platforms use xcodebuild, `android` uses Swift Android SDK. When `null`, uses SwiftPM (swift build/test). **Note:** Android is auto-detected when any `android-*` parameter is set (explicit `type: android` not required) |
 | `xcode` | Xcode version path for Apple platforms | System default | `/Applications/Xcode_15.4.app` | Any Xcode.app path | **Xcode builds only** - iOS, watchOS, tvOS, visionOS, macOS simulator testing |
@@ -94,7 +94,7 @@
 
 - **Ubuntu builds**: Only `working-directory` is used (no `scheme` needed)
 - **macOS SwiftPM builds**: `scheme`, `working-directory` (no `type` specified)
-- **Apple platform builds**: Require `scheme`, `type`, and optionally `deviceName`/`osVersion`
+- **Apple platform builds**: Require `type`, optionally `scheme` (auto-calculated from the Swift package when omitted) and `deviceName`/`osVersion`
 - **Windows builds**: `working-directory`, `windows-swift-version`, `windows-swift-build` (no `scheme` needed)
 - **Android builds**: Auto-detected from any `android-*` parameter (e.g., `android-swift-version`, `android-api-level`). Explicit `type: android` optional but recommended for clarity
 - **Custom Xcode**: When `xcode` is specified, it overrides system default
@@ -2147,9 +2147,9 @@ Code coverage is not currently supported for Android builds. This is a known lim
 |------------|-------------------|----------|---------|
 | **SwiftPM Build** | `—` | `working-directory`, `scheme` (optional) | `type`, `deviceName`, `osVersion`, `use-xcbeautify`, `xcbeautify-renderer` |
 | **Windows Build** | `windows-swift-version`, `windows-swift-build` | `working-directory` | `scheme`, `type`, `deviceName`, `osVersion`, `use-xcbeautify`, `xcbeautify-renderer` |
-| **macOS Native** | `scheme`, `type: macos` | `xcode`, `working-directory`, `use-xcbeautify`, `xcbeautify-renderer` | `deviceName`, `osVersion` |
-| **iOS Simulator** | `scheme`, `type: ios`, `deviceName`, `osVersion` | `xcode`, `download-platform`, `use-xcbeautify`, `xcbeautify-renderer` | None |
-| **Other Simulators** | `scheme`, `type`, `deviceName`, `osVersion` | `xcode`, `download-platform`, `use-xcbeautify`, `xcbeautify-renderer` | None |
+| **macOS Native** | `type: macos` | `scheme` (auto-calculated), `xcode`, `working-directory`, `use-xcbeautify`, `xcbeautify-renderer` | `deviceName`, `osVersion` |
+| **iOS Simulator** | `type: ios`, `deviceName`, `osVersion` | `scheme` (auto-calculated), `xcode`, `download-platform`, `use-xcbeautify`, `xcbeautify-renderer` | None |
+| **Other Simulators** | `type`, `deviceName`, `osVersion` | `scheme` (auto-calculated), `xcode`, `download-platform`, `use-xcbeautify`, `xcbeautify-renderer` | None |
 
 **Q: How do I fix xcbeautify installation issues?**
 

--- a/action.yml
+++ b/action.yml
@@ -768,68 +768,16 @@ runs:
     # When the 'scheme' input is omitted, derive it for Apple-platform (xcodebuild) builds from the
     # Swift package. Convention (matches BrightDigit workflows): a single product uses the product
     # name; multiple products use the SwiftPM aggregate '<PackageName>-Package'. xcodebuild -list is
-    # only a fallback if the manifest cannot be dumped.
+    # only a fallback if the manifest cannot be dumped. See scripts/calculate-scheme.sh.
     - name: Calculate Scheme
-      if: steps.detect-os.outputs.os == 'macos' && inputs.type && inputs.scheme == ''
+      if: steps.detect-os.outputs.os == 'macos' && inputs.type && inputs.type != 'android' && inputs.type != 'wasm' && inputs.type != 'wasm-embedded' && inputs.scheme == ''
       shell: bash
       id: calc-scheme
       working-directory: ${{ inputs.working-directory }}
+      env:
+        WORKING_DIRECTORY: ${{ inputs.working-directory }}
       run: |
-        SCHEME=""
-
-        # The Python helpers are stored in single-quoted shell variables. Every code line is
-        # indented by eight spaces so this YAML block scalar stays valid; that common indentation is
-        # stripped with sed before the code is handed to 'python3 -c', producing valid Python.
-        DUMP_SCHEME_PY='
-        import json, sys
-        try:
-            d = json.load(sys.stdin)
-        except Exception:
-            sys.exit(0)
-        name = d.get("name", "")
-        products = [p.get("name", "") for p in d.get("products", []) if p.get("name")]
-        if len(products) == 1:
-            print(products[0])
-        elif len(products) > 1:
-            print(f"{name}-Package")
-        elif name:
-            print(f"{name}-Package")
-        '
-        if PACKAGE_JSON=$(swift package dump-package 2>/dev/null); then
-          SCHEME=$(printf '%s' "$PACKAGE_JSON" | python3 -c "$(printf '%s\n' "$DUMP_SCHEME_PY" | sed 's/^        //')" 2>/dev/null)
-        fi
-
-        # Fallback: query xcodebuild for available schemes if the manifest could not be parsed
-        if [[ -z "$SCHEME" ]]; then
-          SCHEMES_JSON=$(xcodebuild -list -json 2>/dev/null || echo '')
-          if [[ -n "$SCHEMES_JSON" ]]; then
-            LIST_SCHEME_PY='
-        import json, sys
-        try:
-            d = json.load(sys.stdin)
-        except Exception:
-            sys.exit(0)
-        c = d.get("project") or d.get("workspace") or {}
-        schemes = c.get("schemes", [])
-        pkg = ""
-        for s in schemes:
-            if s.endswith("-Package"):
-                pkg = s
-                break
-        if pkg:
-            print(pkg)
-        elif schemes:
-            print(schemes[0])
-        '
-            SCHEME=$(printf '%s' "$SCHEMES_JSON" | python3 -c "$(printf '%s\n' "$LIST_SCHEME_PY" | sed 's/^        //')" 2>/dev/null)
-          fi
-        fi
-
-        if [[ -z "$SCHEME" ]]; then
-          echo "ERROR: Could not auto-calculate an Xcode scheme. Provide the 'scheme' input explicitly." >&2
-          exit 1
-        fi
-
+        SCHEME=$("$GITHUB_ACTION_PATH/scripts/calculate-scheme.sh")
         echo "scheme=$SCHEME" >> $GITHUB_OUTPUT
         echo "Calculated scheme: $SCHEME"
 

--- a/action.yml
+++ b/action.yml
@@ -774,8 +774,6 @@ runs:
       shell: bash
       id: calc-scheme
       working-directory: ${{ inputs.working-directory }}
-      env:
-        WORKING_DIRECTORY: ${{ inputs.working-directory }}
       run: |
         SCHEME=$("$GITHUB_ACTION_PATH/scripts/calculate-scheme.sh")
         echo "scheme=$SCHEME" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -46,12 +46,14 @@ inputs:
     required: false
     default: '.'
 
-  # The scheme name to build and test (REQUIRED)
-  # Must match a scheme defined in your Package.swift or .xcodeproj
+  # The scheme name to build and test (optional)
+  # When omitted on Apple-platform builds, the scheme is auto-calculated from the Swift package:
+  #   a single product -> the product name; multiple products -> '<PackageName>-Package'
+  # Provide explicitly to override. Must match a scheme defined in your Package.swift or .xcodeproj
   # Examples: 'MyPackage', 'MyLibrary', 'MyApp-iOS'
   scheme:
-    description: 'The scheme to build and test'
-    required: true
+    description: 'The scheme to build and test (auto-calculated from the Swift package when omitted on Apple platforms)'
+    required: false
 
   # Platform type for builds and testing
   # Apple platforms: 'ios', 'watchOS', 'visionOS', 'tvOS', 'macOS'
@@ -761,6 +763,75 @@ runs:
             echo "SDK=macosx" >> $GITHUB_ENV
             ;;
         esac
+
+    # Calculate Xcode Scheme
+    # When the 'scheme' input is omitted, derive it for Apple-platform (xcodebuild) builds from the
+    # Swift package. Convention (matches BrightDigit workflows): a single product uses the product
+    # name; multiple products use the SwiftPM aggregate '<PackageName>-Package'. xcodebuild -list is
+    # only a fallback if the manifest cannot be dumped.
+    - name: Calculate Scheme
+      if: steps.detect-os.outputs.os == 'macos' && inputs.type && inputs.scheme == ''
+      shell: bash
+      id: calc-scheme
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        SCHEME=""
+
+        # The Python helpers are stored in single-quoted shell variables. Every code line is
+        # indented by eight spaces so this YAML block scalar stays valid; that common indentation is
+        # stripped with sed before the code is handed to 'python3 -c', producing valid Python.
+        DUMP_SCHEME_PY='
+        import json, sys
+        try:
+            d = json.load(sys.stdin)
+        except Exception:
+            sys.exit(0)
+        name = d.get("name", "")
+        products = [p.get("name", "") for p in d.get("products", []) if p.get("name")]
+        if len(products) == 1:
+            print(products[0])
+        elif len(products) > 1:
+            print(f"{name}-Package")
+        elif name:
+            print(f"{name}-Package")
+        '
+        if PACKAGE_JSON=$(swift package dump-package 2>/dev/null); then
+          SCHEME=$(printf '%s' "$PACKAGE_JSON" | python3 -c "$(printf '%s\n' "$DUMP_SCHEME_PY" | sed 's/^        //')" 2>/dev/null)
+        fi
+
+        # Fallback: query xcodebuild for available schemes if the manifest could not be parsed
+        if [[ -z "$SCHEME" ]]; then
+          SCHEMES_JSON=$(xcodebuild -list -json 2>/dev/null || echo '')
+          if [[ -n "$SCHEMES_JSON" ]]; then
+            LIST_SCHEME_PY='
+        import json, sys
+        try:
+            d = json.load(sys.stdin)
+        except Exception:
+            sys.exit(0)
+        c = d.get("project") or d.get("workspace") or {}
+        schemes = c.get("schemes", [])
+        pkg = ""
+        for s in schemes:
+            if s.endswith("-Package"):
+                pkg = s
+                break
+        if pkg:
+            print(pkg)
+        elif schemes:
+            print(schemes[0])
+        '
+            SCHEME=$(printf '%s' "$SCHEMES_JSON" | python3 -c "$(printf '%s\n' "$LIST_SCHEME_PY" | sed 's/^        //')" 2>/dev/null)
+          fi
+        fi
+
+        if [[ -z "$SCHEME" ]]; then
+          echo "ERROR: Could not auto-calculate an Xcode scheme. Provide the 'scheme' input explicitly." >&2
+          exit 1
+        fi
+
+        echo "scheme=$SCHEME" >> $GITHUB_OUTPUT
+        echo "Calculated scheme: $SCHEME"
 
     # Wasm Swift Version Detection
     # This step detects the installed Swift version and constructs the Wasm SDK name.
@@ -2160,14 +2231,14 @@ runs:
         if [ "${{ inputs.build-only }}" = "true" ]; then
           # Build-only mode: compile without running tests
           XCODEBUILD_CMD="xcodebuild build \
-            -scheme ${{ inputs.scheme }} \
+            -scheme ${{ inputs.scheme || steps.calc-scheme.outputs.scheme }} \
             -sdk ${{ env.SDK }} \
             -destination \"$DESTINATION\" \
             -derivedDataPath ${{ env.DERIVED_DATA_PATH }}"
         else
           # Normal mode: build and run tests with coverage
           XCODEBUILD_CMD="xcodebuild test \
-            -scheme ${{ inputs.scheme }} \
+            -scheme ${{ inputs.scheme || steps.calc-scheme.outputs.scheme }} \
             -sdk ${{ env.SDK }} \
             -destination \"$DESTINATION\" \
             -enableCodeCoverage YES \

--- a/scripts/calculate-scheme.sh
+++ b/scripts/calculate-scheme.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Calculate the Xcode scheme for a Swift package.
+# Prints ONLY the scheme name to stdout; warnings/errors go to stderr.
+#
+# Derivation (BrightDigit convention):
+#   - 1 product            -> that product's name
+#   - >1 products          -> "<packageName>-Package"
+#   - 0 products, has name -> "<packageName>-Package"
+# Fallback (only if the above yields nothing): xcodebuild -list -json,
+# picking the first scheme that ends in "-Package".
+#
+# Optional env var WORKING_DIRECTORY: if set and non-empty, cd into it first.
+# Exits 0 on success, 1 if no scheme could be determined.
+
+set -euo pipefail
+
+if [ -n "${WORKING_DIRECTORY:-}" ]; then
+  cd "$WORKING_DIRECTORY"
+fi
+
+SCHEME=""
+
+# Primary: derive from the Swift package manifest.
+if PACKAGE_JSON=$(swift package dump-package 2>/dev/null); then
+  SCHEME=$(printf '%s' "$PACKAGE_JSON" | jq -r 'if (.products|length)==1 then .products[0].name elif (.products|length)>1 then "\(.name)-Package" elif (.name // "")!="" then "\(.name)-Package" else empty end')
+else
+  echo "warning: 'swift package dump-package' failed; trying 'xcodebuild -list' fallback" >&2
+fi
+
+# Fallback: only if no scheme was derived above.
+if [ -z "$SCHEME" ]; then
+  SCHEMES_JSON=$(xcodebuild -list -json 2>/dev/null || true)
+  if [ -n "$SCHEMES_JSON" ]; then
+    SCHEME=$(printf '%s' "$SCHEMES_JSON" | jq -r '((.project // .workspace // {}).schemes // []) | map(select(endswith("-Package"))) | .[0] // empty')
+  fi
+fi
+
+if [ -z "$SCHEME" ]; then
+  echo "ERROR: Could not auto-calculate an Xcode scheme. Provide the 'scheme' input explicitly." >&2
+  exit 1
+fi
+
+printf '%s\n' "$SCHEME"


### PR DESCRIPTION
## Summary
Makes the `scheme` input optional and auto-calculates it for Apple-platform (xcodebuild) builds when omitted.

Derivation (from `swift package dump-package`), matching the convention across BrightDigit workflows:
- **1 product** → the product's name (e.g. SyndiKit, DataThespian → `<PackageName>`).
- **>1 products** → the SwiftPM aggregate `<PackageName>-Package` (e.g. MistKit, SyntaxKit, BushelKit, RadiantKit).
- Fallback to `xcodebuild -list -json` only if the manifest cannot be dumped.

`scheme` is changed to `required: false`; an explicitly provided `scheme` still takes precedence (backward compatible). README updated.

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)