### PR TITLE
Bump macos-26 CI runners to Xcode 26.5 / platform 26.5

### DIFF
--- a/.github/workflows/swift-test.yml
+++ b/.github/workflows/swift-test.yml
@@ -68,9 +68,9 @@ jobs:
 
           - type: ios
             runs-on: macos-26
-            xcode: "/Applications/Xcode_26.4.app"
+            xcode: "/Applications/Xcode_26.5.app"
             deviceName: "iPhone 17 Pro"
-            osVersion: "26.4"
+            osVersion: "26.5"
             download-platform: "true"
             use-xcbeautify: "true"
             xcbeautify-renderer: "github-actions"
@@ -83,9 +83,9 @@ jobs:
 
           - type: watchos
             runs-on: macos-26
-            xcode: "/Applications/Xcode_26.4.app"
+            xcode: "/Applications/Xcode_26.5.app"
             deviceName: "Apple Watch Ultra 3 (49mm)"
-            osVersion: "26.4"
+            osVersion: "26.5"
             download-platform: "true"
             use-xcbeautify: "true"
             xcbeautify-renderer: "azure-devops-pipelines"
@@ -104,9 +104,9 @@ jobs:
 
           - type: tvos
             runs-on: macos-26
-            xcode: "/Applications/Xcode_26.4.app"
+            xcode: "/Applications/Xcode_26.5.app"
             deviceName: "Apple TV 4K (3rd generation)"
-            osVersion: "26.4"
+            osVersion: "26.5"
             download-platform: "true"
             use-xcbeautify: "true"
             xcbeautify-renderer: "github-actions"
@@ -186,9 +186,9 @@ jobs:
 
           - type: ios
             runs-on: macos-26
-            xcode: "/Applications/Xcode_26.4.app"
+            xcode: "/Applications/Xcode_26.5.app"
             deviceName: "iPhone 17 Pro"
-            osVersion: "26.4"
+            osVersion: "26.5"
             download-platform: "true"
             use-xcbeautify: "true"
             xcbeautify-renderer: "github-actions"
@@ -201,9 +201,9 @@ jobs:
 
           - type: watchos
             runs-on: macos-26
-            xcode: "/Applications/Xcode_26.4.app"
+            xcode: "/Applications/Xcode_26.5.app"
             deviceName: "Apple Watch Ultra 3 (49mm)"
-            osVersion: "26.4"
+            osVersion: "26.5"
             download-platform: "true"
             use-xcbeautify: "true"
             xcbeautify-renderer: "azure-devops-pipelines"
@@ -222,9 +222,9 @@ jobs:
 
           - type: tvos
             runs-on: macos-26
-            xcode: "/Applications/Xcode_26.4.app"
+            xcode: "/Applications/Xcode_26.5.app"
             deviceName: "Apple TV 4K (3rd generation)"
-            osVersion: "26.4"
+            osVersion: "26.5"
             download-platform: "true"
             use-xcbeautify: "true"
             xcbeautify-renderer: "github-actions"
@@ -1086,9 +1086,9 @@ jobs:
               -Xlinker --max-memory=536870912
             # Note: NO wasmtime-version parameter → uses WasmKit runtime
 
-          # WasmKit (default) - macOS 26 with Wasm and Xcode 26.4
+          # WasmKit (default) - macOS 26 with Wasm and Xcode 26.5
           - runs-on: macos-26
-            xcode: "/Applications/Xcode_26.4.app"
+            xcode: "/Applications/Xcode_26.5.app"
             type: wasm
             build-only: false
             wasm-swift-flags: >-
@@ -1101,9 +1101,9 @@ jobs:
               -Xlinker --max-memory=536870912
             # Note: NO wasmtime-version parameter → uses WasmKit runtime
 
-          # WasmKit (default) - macOS 26 with Wasm-embedded and Xcode 26.4
+          # WasmKit (default) - macOS 26 with Wasm-embedded and Xcode 26.5
           - runs-on: macos-26
-            xcode: "/Applications/Xcode_26.4.app"
+            xcode: "/Applications/Xcode_26.5.app"
             type: wasm-embedded
             build-only: false
             wasm-swift-flags: >-
@@ -1133,7 +1133,7 @@ jobs:
 
           # Wasmtime fallback - macOS 26 with WASM and specific version
           - runs-on: macos-26
-            xcode: "/Applications/Xcode_26.4.app"
+            xcode: "/Applications/Xcode_26.5.app"
             type: wasm
             wasmtime-version: '27.0.0'  # Explicit Wasmtime fallback with specific version
             build-only: false
@@ -1242,9 +1242,9 @@ jobs:
               -Xlinker --max-memory=536870912
             # Note: NO wasmtime-version parameter → uses WasmKit runtime
 
-          # WasmKit (default) - macOS 26 with Wasm and Xcode 26.4
+          # WasmKit (default) - macOS 26 with Wasm and Xcode 26.5
           - runs-on: macos-26
-            xcode: "/Applications/Xcode_26.4.app"
+            xcode: "/Applications/Xcode_26.5.app"
             type: wasm
             build-only: false
             wasm-swift-flags: >-
@@ -1257,9 +1257,9 @@ jobs:
               -Xlinker --max-memory=536870912
             # Note: NO wasmtime-version parameter → uses WasmKit runtime
 
-          # WasmKit (default) - macOS 26 with Wasm-embedded and Xcode 26.4
+          # WasmKit (default) - macOS 26 with Wasm-embedded and Xcode 26.5
           - runs-on: macos-26
-            xcode: "/Applications/Xcode_26.4.app"
+            xcode: "/Applications/Xcode_26.5.app"
             type: wasm-embedded
             build-only: false
             wasm-swift-flags: >-
@@ -1289,7 +1289,7 @@ jobs:
 
           # Wasmtime fallback - macOS 26 with WASM and specific version
           - runs-on: macos-26
-            xcode: "/Applications/Xcode_26.4.app"
+            xcode: "/Applications/Xcode_26.5.app"
             type: wasm
             wasmtime-version: '27.0.0'  # Explicit Wasmtime fallback with specific version
             build-only: false
@@ -1350,7 +1350,7 @@ jobs:
 
           # WasmKit (default) - macOS 26 with Wasm
           - runs-on: macos-26
-            xcode: "/Applications/Xcode_26.4.app"
+            xcode: "/Applications/Xcode_26.5.app"
             type: wasm
             build-only: false
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@
 | Output | Description | Example Values | Usage |
 |--------|-------------|----------------|-------|
 | `contains-code-coverage` | Whether this build contains code coverage data | `'true'`, `'false'` | Returns `'true'` for SwiftPM and Xcode builds with tests enabled. Returns `'false'` for Wasm builds (not supported), Android builds (handled separately), Windows builds (not supported), and build-only mode. Use this to conditionally run coverage collection actions. |
-| `xcode-version` | The Xcode version used for the build | `'16.4'`, `'26.4'` | Only populated on macOS runners. Empty for Ubuntu, Windows, Android, and Wasm. |
+| `xcode-version` | The Xcode version used for the build | `'16.4'`, `'26.5'` | Only populated on macOS runners. Empty for Ubuntu, Windows, Android, and Wasm. |
 | `swift-version` | The Swift version used for the build | `'6.2.3'`, `'6.3'` | Populated for macOS, Ubuntu, Windows, and Wasm via `swift --version`. For Android, reflects the `android-swift-version` input (blank if not specified). |
 
 **Usage Example**:


### PR DESCRIPTION
## Summary

The `macos-26-arm64` runner image was updated, causing the `macos-26` CI jobs to fail against the pinned Xcode 26.4 / `osVersion` 26.4 configuration. This moves all `macos-26` matrix entries to the latest available Xcode and matching platform runtime.

Per the [current image readme](https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md):
- Latest Xcode: **26.5** at `/Applications/Xcode_26.5.app`
- Installed simulator runtimes include **26.5** (iOS/watchOS/tvOS/visionOS)
- Device names already in the matrix (iPhone 17 Pro, Apple Watch Ultra 3, Apple TV 4K, Apple Vision Pro) remain valid under 26.5

## Changes

- `.github/workflows/swift-test.yml`:
  - `Xcode_26.4.app` → `Xcode_26.5.app` (13 macos-26 entries: iOS/watchOS/tvOS + Wasm/Wasm-embedded)
  - `osVersion: "26.4"` → `"26.5"` (6 simulator entries)
  - Updated the related "Xcode 26.4" comments to 26.5
- `README.md`: bumped the `xcode-version` output example `'26.4'` → `'26.5'`

## Verification

- No stale `26.4` references remain in the workflow
- Workflow YAML parses cleanly
- CI will confirm the macos-26 jobs go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD Swift test workflows to use Xcode 26.5 across all supported platforms (macOS, iOS, tvOS, watchOS), including corresponding OS version and device target updates. Wasm test configurations also updated to Xcode 26.5.

* **Documentation**
  * Updated README to reflect current Xcode version references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/brightdigit/swift-build/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->