### PR TITLE
Include compiler commit in SPM cache keys for nightly toolchains

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1257,23 +1257,29 @@ runs:
         deriveddata-directory: ${{ env.DERIVED_DATA_PATH }}
 
     # Ubuntu specific steps
+    # SWIFT_VERSION feeds the SPM cache key. For nightly toolchains the script appends
+    # the exact compiler commit (e.g. 6.4-dev-348f9c2e6608448) so a snapshot bump
+    # invalidates the cache instead of restoring .build/ artifacts compiled by an
+    # older snapshot (ABI drift between snapshots causes miscompiles; see issue #109).
     - name: Get Swift and OS versions
       if: steps.detect-os.outputs.os == 'ubuntu'
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        SWIFT_VERSION=$(swift --version | head -n 1 | cut -d ' ' -f 3)
+        SWIFT_VERSION=$(swift --version | "$GITHUB_ACTION_PATH/scripts/swift-version-cache-key.sh")
         echo "SWIFT_VERSION=$SWIFT_VERSION" >> $GITHUB_ENV
         OS_VERSION=$(. /etc/os-release && echo $VERSION_CODENAME)
         echo "OS_VERSION=$OS_VERSION" >> $GITHUB_ENV
 
     # Windows specific steps
+    # SWIFT_VERSION feeds the SPM cache key; nightly toolchains get the exact compiler
+    # commit appended (see the Ubuntu step above and issue #109).
     - name: Get Swift version for Windows
       if: steps.detect-os.outputs.os == 'windows'
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        SWIFT_VERSION=$(swift --version | head -n 1 | cut -d ' ' -f 3)
+        SWIFT_VERSION=$(swift --version | "$GITHUB_ACTION_PATH/scripts/swift-version-cache-key.sh")
         echo "SWIFT_VERSION=$SWIFT_VERSION" >> $GITHUB_ENV
         # Get Windows version and build number for cache key using simple registry lookup
         # This provides better cache isolation based on Windows version and build
@@ -1347,7 +1353,8 @@ runs:
     # Cache Key Strategy:
     # - Pattern: spm-{UbuntuVersion}-{SwiftVersion}-{PackageHash}-{ResolvedHash}-{BuildOnly}
     # - OS version isolation (focal/jammy/noble) ensures ABI compatibility
-    # - Swift version isolation prevents toolchain conflicts
+    # - Swift version isolation prevents toolchain conflicts; nightly toolchains include
+    #   the compiler commit (e.g. 6.4-dev-348f9c2e6608448) so snapshot bumps invalidate the cache
     # - PackageHash: Unique identifier per Swift package (prevents cache collisions between packages)
     # - ResolvedHash: Either Package.resolved hash or 'no-resolved' (see detect-resolved step)
     # - BuildOnly: Separates build-only from test builds to prevent test binary contamination
@@ -1376,7 +1383,8 @@ runs:
     # Cache Key Strategy:
     # - Pattern: spm-windows-{WindowsProductNameSlug}-{BuildNumber}-{SwiftVersion}-{PackageHash}-{ResolvedHash}-{BuildOnly}
     # - Windows version and build isolation ensures toolchain compatibility
-    # - Swift version isolation prevents conflicts between different Windows Swift builds
+    # - Swift version isolation prevents conflicts between different Windows Swift builds;
+    #   nightly toolchains include the compiler commit so snapshot bumps invalidate the cache
     # - PackageHash: Unique identifier per Swift package (prevents cache collisions between packages)
     # - ResolvedHash: Either Package.resolved hash or 'no-resolved' (see detect-resolved step)
     # - BuildOnly: Separates build-only from test builds to prevent test binary contamination

--- a/scripts/swift-version-cache-key.sh
+++ b/scripts/swift-version-cache-key.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Computes the Swift version component used in SPM cache keys from 'swift --version' output
+# Usage: swift --version | scripts/swift-version-cache-key.sh
+# Output: the third field of the version line (e.g. '6.2.3'), unchanged for release
+#         toolchains. For development snapshots (e.g. '6.4-dev'), the exact Swift
+#         compiler commit from the parenthetical is appended (e.g.
+#         '6.4-dev-348f9c2e6608448') so each nightly snapshot gets its own cache
+#         namespace instead of sharing one stale '6.4-dev' key across snapshots.
+# Exit codes: 0 = success (always; falls back to the plain version when no commit is found)
+
+set -euo pipefail
+
+FIRST_LINE=$(head -n 1)
+SWIFT_VERSION=$(echo "$FIRST_LINE" | cut -d ' ' -f 3)
+
+case "$SWIFT_VERSION" in
+  *-dev)
+    # Nightly toolchains all report the same X.Y-dev version; only the parenthetical
+    # identifies the snapshot, e.g. "Swift version 6.4-dev (LLVM d1ef843cdc2991c, Swift 348f9c2e6608448)"
+    SWIFT_COMMIT=$(echo "$FIRST_LINE" | sed -nE 's/.*Swift ([0-9a-f]{7,40})\).*/\1/p')
+    if [ -n "$SWIFT_COMMIT" ]; then
+      SWIFT_VERSION="${SWIFT_VERSION}-${SWIFT_COMMIT}"
+    fi
+    ;;
+esac
+
+echo "$SWIFT_VERSION"


### PR DESCRIPTION
## Problem

The Ubuntu and Windows SPM cache keys take `SWIFT_VERSION` from field 3 of `swift --version`, which yields the same value (e.g. `6.4-dev`) for **every nightly snapshot** of a Swift release. Workflows running in nightly-toolchain containers (e.g. `swiftlang/swift:nightly-6.4.x-noble` derivatives) restore a stale `.build/` compiled by an older snapshot after the image is bumped — ABI drift between snapshots then causes confusing build failures or miscompiles (brightdigit/brightdigit.com#65 was a deployed-binary segfault from exactly this).

## Fix

The exact snapshot identity is already in the version line — it was just being discarded:

```
Swift version 6.4-dev (LLVM d1ef843cdc2991c, Swift 348f9c2e6608448)
```

A new shared script, `scripts/swift-version-cache-key.sh`, keeps the existing field-3 parse and, when the version ends in `-dev`, appends the Swift compiler commit from the parenthetical. Nightly cache keys become e.g. `spm-noble-6.4-dev-348f9c2e6608448-...`, so a snapshot bump rotates the key automatically — no consumer-side wiring needed. The commit is also human-traceable: it matches what `swift --version` prints in the build log.

This fixes the default behavior for all nightly consumers, rather than requiring callers to pass extra entropy (the `cache-key-suffix` input originally proposed in #109 was dropped as unnecessary).

## Non-breaking

- Release toolchains (`6.2.3`, `5.10.1`, …) don't match `*-dev`, so their keys are byte-identical to before — no mass cache invalidation.
- Nightly keys change once, which is the point: the old shared key was the bug.
- If no commit can be parsed from a `-dev` version line, the script falls back to the plain version (current behavior).

## Testing

Verified against real toolchains:

| Input (first line) | Output |
|---|---|
| `Swift version 6.2.3 (swift-6.2.3-RELEASE)` (swift:6.2-noble) | `6.2.3` |
| `Swift version 6.4-dev (LLVM d1ef843…, Swift 348f9c2…)` (nightly 6.4 container) | `6.4-dev-348f9c2e6608448` |
| `Swift version 6.2.3-dev (LLVM 9784760…, Swift a6aa30f…)` (swiftlang/swift:nightly-6.2-noble) | `6.2.3-dev-a6aa30f93ec1885` |
| `Swift version 6.4-dev (no parenthetical here)` | `6.4-dev` (fallback) |

`shellcheck` passes on the new script; `action.yml` parses cleanly.

Closes #109. Consumer-side follow-up tracked in brightdigit/brightdigit.com#79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)